### PR TITLE
TW: July 2nd Sync

### DIFF
--- a/url_shortener/templates/create_url_mapping.html
+++ b/url_shortener/templates/create_url_mapping.html
@@ -1,0 +1,23 @@
+<!-- create_url_mapping.html -->
+
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Create URL Mapping</title>
+</head>
+<body>
+    <h1>Create URL Mapping</h1>
+
+    <form method="post">
+        {% csrf_token %}
+
+        <label for="short_code">Short Code:</label>
+        <input type="text" id="short_code" name="short_code" required><br>
+
+        <label for="long_url">Long URL:</label>
+        <input type="url" id="long_url" name="long_url" required><br>
+
+        <input type="submit" value="Create">
+    </form>
+</body>
+</html>

--- a/url_shortener/templates/url_mapping_list.html
+++ b/url_shortener/templates/url_mapping_list.html
@@ -1,0 +1,28 @@
+<!-- url_mapping_list.html -->
+
+<!DOCTYPE html>
+<html>
+<head>
+    <title>URL Mappings</title>
+</head>
+<body>
+    <h1>URL Mappings</h1>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Short Code</th>
+                <th>Long URL</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for urlmapping in urlmappings %}
+            <tr>
+                <td>{{ urlmapping.short_code }}</td>
+                <td>{{ urlmapping.long_url }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/url_shortener/url_shortener/settings.py
+++ b/url_shortener/url_shortener/settings.py
@@ -56,7 +56,8 @@ ROOT_URLCONF = "url_shortener.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        # Note: search in the templates/ dir for all templates.
+        "DIRS": ["templates/"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -78,9 +79,9 @@ WSGI_APPLICATION = "url_shortener.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "db",
-        "USER": "user",
-        "PASSWORD": "password",
+        "NAME": "urlcompress",
+        "USER": "postgres",
+        "PASSWORD": "postgres",
         "HOST": "127.0.0.1",
         "PORT": 5432,
     }

--- a/url_shortener/url_shortener/urls.py
+++ b/url_shortener/url_shortener/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from url_shortener_app.views import URLMappingListView
+from url_shortener_app.views import URLMappingListView, URLMappingCreateView
 
 # Defining URL patterns for our application
 urlpatterns = [
@@ -25,5 +25,5 @@ urlpatterns = [
 
     # API URL pattern to include the generated URLs by the router
     path('urlmappings/', URLMappingListView.as_view(), name= 'urlmapping-list'),
-
+    path('createurlmapping/', URLMappingCreateView.as_view(), name= 'urlmapping-create'),
 ]

--- a/url_shortener/url_shortener/urls.py
+++ b/url_shortener/url_shortener/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from url_shortener_app.views import URLMappingListView, URLMappingCreateView
+from url_shortener_app.views import URLMappingListView, URLMappingCreateView, list_urlmappings
 
 # Defining URL patterns for our application
 urlpatterns = [
@@ -25,5 +25,6 @@ urlpatterns = [
 
     # API URL pattern to include the generated URLs by the router
     path('urlmappings/', URLMappingListView.as_view(), name= 'urlmapping-list'),
+    path('api/urlmappings/', list_urlmappings, name= 'api-urlmapping-list'),
     path('createurlmapping/', URLMappingCreateView.as_view(), name= 'urlmapping-create'),
 ]

--- a/url_shortener/url_shortener_app/forms.py
+++ b/url_shortener/url_shortener_app/forms.py
@@ -1,0 +1,8 @@
+from django import forms
+from .models import URLMapping
+
+# Note: we get form validation on `long_url` for free since it'll throw an error if we try to write it to the database. 
+class URLMappingForm(forms.ModelForm):
+    class Meta:
+        model = URLMapping
+        fields = ['short_code', 'long_url']

--- a/url_shortener/url_shortener_app/views.py
+++ b/url_shortener/url_shortener_app/views.py
@@ -2,8 +2,17 @@ from django.shortcuts import render, redirect
 from django.views.generic import ListView, CreateView
 from .models import URLMapping
 from .forms import URLMappingForm
+from django.http import JsonResponse
 
 # Create your views here.
+def list_urlmappings(request):
+    urlmappings = URLMapping.objects.all()
+
+    data = {
+        'urlmappings': list(urlmappings.values())
+    }
+
+    return JsonResponse(data)
 
 # Define a list view for all URLMapping objects
 class URLMappingListView(ListView):

--- a/url_shortener/url_shortener_app/views.py
+++ b/url_shortener/url_shortener_app/views.py
@@ -1,10 +1,11 @@
-from django.shortcuts import render
-from django.views.generic import ListView
+from django.shortcuts import render, redirect
+from django.views.generic import ListView, CreateView
 from .models import URLMapping
+from .forms import URLMappingForm
 
 # Create your views here.
 
-# Define a viewset for URLMapping Model
+# Define a list view for all URLMapping objects
 class URLMappingListView(ListView):
    '''
    A View that displays a list of URLMappings.
@@ -18,3 +19,25 @@ class URLMappingListView(ListView):
 
    # Specify the context variable name to use in the template
    context_object_name = 'urlmappings'
+
+# Define a view for creating a new URLMapping object
+class URLMappingCreateView(CreateView):
+    '''
+    A View that creates a new URLMapping object.
+    Inherits from Django's CreateView class
+    '''
+
+    # Specify the model to use for the view
+    model = URLMapping
+
+    # Specify the form class to use for the view
+    form_class = URLMappingForm
+
+    # Specify the template to render for the view
+    template_name = 'create_url_mapping.html'
+
+    def form_valid(self, form):
+        # Called when the submitted form is valid
+        # Save the form and redirect to the URLMapping list view
+        self.object = form.save()
+        return redirect('/urlmappings/')


### PR DESCRIPTION
#### Includes:
- added view (class-based and function-based)
- added templates (I asked chatGPT to generate these tbh)
- updated settings.py to find templates

#### QA:
- create view
<img width="1279" alt="Screenshot 2023-07-02 at 7 58 40 PM" src="https://github.com/christlineedward/URLcompress/assets/20159234/37783f76-de77-49c1-beed-a1685adeb3f9">

- list view
<img width="1280" alt="Screenshot 2023-07-02 at 7 58 29 PM" src="https://github.com/christlineedward/URLcompress/assets/20159234/9b362f75-4c6e-4daf-aed0-cd67854ac0b0">

- JSON response endpoint:
- using `curl -X GET http://localhost:8000/api/urlmappings/`
<img width="840" alt="Screenshot 2023-07-02 at 8 08 37 PM" src="https://github.com/christlineedward/URLcompress/assets/20159234/1e210174-2904-4241-8d52-b3861911f97a">
